### PR TITLE
fix: ai운동비서 자세히보기 버튼 - 바텀시트 이동

### DIFF
--- a/app/src/main/java/com/cookandroid/challengers/AiRecommendationBottomSheet.kt
+++ b/app/src/main/java/com/cookandroid/challengers/AiRecommendationBottomSheet.kt
@@ -1,0 +1,65 @@
+package com.cookandroid.challengers
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import com.cookandroid.challengers.databinding.FragmentAiRecommendationBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class AiRecommendationBottomSheet : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentAiRecommendationBinding? = null
+    private val binding get() = _binding!!
+
+    companion object {
+        const val TAG = "AiRecommendationBottomSheet"
+        private const val ARG_CONTENT = "content"
+
+        fun newInstance(content: String): AiRecommendationBottomSheet {
+            return AiRecommendationBottomSheet().apply {
+                arguments = bundleOf(ARG_CONTENT to content)
+            }
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = BottomSheetDialog(requireContext(), R.style.BottomSheetDialogTheme)
+        dialog.setOnShowListener { dialogInterface ->
+            val bottomSheet = (dialogInterface as BottomSheetDialog)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            bottomSheet?.let {
+                it.background = ContextCompat.getDrawable(requireContext(), R.drawable.bottom_sheet_background)
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                behavior.skipCollapsed = true
+            }
+        }
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentAiRecommendationBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 전달받은 텍스트
+        val content = arguments?.getString(ARG_CONTENT) ?: "내용을 불러올 수 없습니다."
+        binding.contentTextView.text = content
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/cookandroid/challengers/RecordDateFragment.kt
+++ b/app/src/main/java/com/cookandroid/challengers/RecordDateFragment.kt
@@ -68,6 +68,15 @@ class RecordDateFragment : Fragment() {
             override fun onTabUnselected(tab: TabLayout.Tab?) {}
             override fun onTabReselected(tab: TabLayout.Tab?) {}
         })
+
+        binding.btnAiComment.setOnClickListener {
+            // bottomSheetText 가져옴
+            val detailContent = recordDateViewModel.bottomSheetText.value ?: "잠시만 기다려주세요...\n데이터를 불러오고 있습니다."
+
+            // 상세 내용을 담아 바텀 시트 열기
+            val bottomSheet = AiRecommendationBottomSheet.newInstance(detailContent)
+            bottomSheet.show(parentFragmentManager, AiRecommendationBottomSheet.TAG)
+        }
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/cookandroid/challengers/viewmodel/RecordDateViewModel.kt
+++ b/app/src/main/java/com/cookandroid/challengers/viewmodel/RecordDateViewModel.kt
@@ -26,6 +26,8 @@ class RecordDateViewModel(application: Application) : AndroidViewModel(applicati
     private val _recommendationText = MutableLiveData<String>()
     val recommendationText: LiveData<String> = _recommendationText
 
+    private val _bottomSheetText = MutableLiveData<String>()
+    val bottomSheetText: LiveData<String> = _bottomSheetText
 
     init {
         loadMonthlySummary() // ViewModel 생성 시 요약 정보 로드
@@ -136,9 +138,22 @@ class RecordDateViewModel(application: Application) : AndroidViewModel(applicati
                 Log.d("AdviceAPI", " 응답 도착 → code=${response.code()} body=${response.body()} error=${response.errorBody()?.string()}")
 
                 if (response.isSuccessful) {
-                    val text = response.body()?.advice ?: "분석 결과가 없습니다."
-                    Log.d("AdviceAPI", " 성공! advice=$text")
-                    _recommendationText.value = text
+                    // 서버에서 받은 메인 멘트
+                    val resultText = response.body()?.advice ?: "분석 결과가 없습니다."
+
+                    // 메인 화면 업데이트 (서버 값 그대로)
+                    _recommendationText.value = resultText
+
+                    // 바텀 시트 텍스트 업데이트
+                    _bottomSheetText.value = """
+                        [AI 상세 분석 리포트]
+                        
+                        회원님의 운동 기록을 바탕으로 분석된 상세 내용입니다.
+                        이곳에는 서버에서 받아온 더 긴 텍스트나,
+                        구체적인 운동 추천 목록이 들어갈 예정입니다.
+                        
+                        현재 메인 화면에는 "$resultText" 라고 표시되고 있습니다.
+                    """.trimIndent()
                 } else {
                     Log.e("AdviceAPI", " 실패! code=${response.code()} message=${response.message()} error=${response.errorBody()?.string()}")
                     _recommendationText.value = "운동 분석을 가져오지 못했습니다."

--- a/app/src/main/res/layout/fragment_ai_recommendation.xml
+++ b/app/src/main/res/layout/fragment_ai_recommendation.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent"
+    android:minHeight="400dp"
+    android:paddingBottom="30dp">
+
+    <ImageView
+        android:id="@+id/dragHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:src="@drawable/ic_timer_bar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/titleTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="AI 운동 비서"
+        android:textColor="@color/black"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dragHandle" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="24dp"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/titleTextView">
+
+        <TextView
+            android:id="@+id/contentTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="AI 추천 내용을 불러오는 중입니다..."
+            android:textColor="#424242"
+            android:textSize="16sp"
+            android:lineSpacingExtra="6dp"/>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_record_date.xml
+++ b/app/src/main/res/layout/fragment_record_date.xml
@@ -217,6 +217,7 @@
 
 
                 <TextView
+                    android:id="@+id/btnAiComment"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"


### PR DESCRIPTION
## 📝 Explanation
ai 운동 비서 아래 '자세히보기' 버튼 누르면 바텀 시트가 열리도록 수정  

- TopBar 파일 이동 위주
- Bottom Navigation 개편 및 중앙 FAB 추가

## ✔️ PR Type
- [ ] Add new features

```mermaid
sequenceDiagram
    participant U as User
    participant App as MainApp
    participant Nav as LinkuNavigationBar
    participant VM as HomeViewModel
    participant R as Router

    U->>Nav: 탭 아이템 탭(Feeds)
    Nav->>App: onNavClick(item=Feeds)
    App->>R: navigate("/feeds")
    R-->>VM: onRouteChanged("/feeds")
    VM-->>App: UiState(feeds, selected=Feeds)
    App-->>Nav: props { selected=Feeds, badge=... }

    U->>Nav: 중앙 FAB 클릭
    Nav->>App: onFabClick()
    App->>R: navigate("/quick-link")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI comment button to the exercise record screen for accessing AI-generated recommendations
  * Implemented a bottom sheet dialog displaying detailed AI exercise advice and personalized guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->