### PR TITLE
fix: 기록탭 스크롤 끝까지 안되는 문제 / 아이템 구매 alert창 사이즈 수정

### DIFF
--- a/app/src/main/java/com/cookandroid/challengers/StoreItemPopUpFragment.kt
+++ b/app/src/main/java/com/cookandroid/challengers/StoreItemPopUpFragment.kt
@@ -118,7 +118,7 @@ class StoreItemPopUpFragment : DialogFragment() {
     override fun onStart() {
         super.onStart()
         dialog?.window?.apply {
-            val desiredMarginDp = 16
+            val desiredMarginDp = 40
             val displayMetrics = requireContext().resources.displayMetrics
             val dialogWidth = displayMetrics.widthPixels - (2 * (desiredMarginDp * displayMetrics.density).toInt())
             setLayout(dialogWidth, ViewGroup.LayoutParams.WRAP_CONTENT)

--- a/app/src/main/res/layout/fragment_challenge_photo.xml
+++ b/app/src/main/res/layout/fragment_challenge_photo.xml
@@ -60,6 +60,7 @@
         android:backgroundTint="@color/blue"
         android:src="@drawable/btn_floating"
         app:elevation="0dp"
+        app:borderWidth="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:tint="@color/white" />

--- a/app/src/main/res/layout/fragment_record_date.xml
+++ b/app/src/main/res/layout/fragment_record_date.xml
@@ -148,6 +148,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="32dp"
+                android:layout_marginBottom="80dp"
                 android:orientation="vertical">
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_record_weight.xml
+++ b/app/src/main/res/layout/fragment_record_weight.xml
@@ -2,14 +2,15 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingBottom="80dp">
+    android:layout_height="match_parent">
 
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:fillViewport="true"
+        android:paddingBottom="80dp"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -20,7 +21,8 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="16dp"
-            android:paddingTop="32dp">
+            android:paddingTop="32dp"
+            android:paddingBottom="80dp">
 
             <TextView
                 android:id="@+id/tvWeightDateRange"
@@ -263,6 +265,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="60dp"
                 android:layout_marginTop="24dp"
+                android:layout_marginBottom="80dp"
                 app:cardElevation="0dp"
                 app:strokeColor="@android:color/transparent"
                 app:strokeWidth="0dp">
@@ -314,10 +317,11 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="32dp"
+        android:layout_marginBottom="100dp"
         android:backgroundTint="@color/blue"
         android:src="@drawable/btn_floating"
         app:elevation="0dp"
+        app:borderWidth="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:tint="@color/white" />

--- a/app/src/main/res/layout/fragment_store_item_pop_up.xml
+++ b/app/src/main/res/layout/fragment_store_item_pop_up.xml
@@ -3,56 +3,53 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="16dp"
+    android:layout_gravity="center"
     android:background="@drawable/btn_rectangle_round5_white"
     android:orientation="vertical"
-    android:paddingHorizontal="16dp"
-    android:paddingVertical="24dp">
+    android:paddingHorizontal="20dp"
+    android:paddingVertical="20dp">
 
     <TextView
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/pretendard_semi_bold"
         android:text="아이템을 구매하시겠습니까?"
         android:textColor="@color/black"
-        android:textSize="24sp" />
+        android:textSize="18sp" />
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="12dp"
         android:background="@drawable/btn_rectangle_round30"
         android:backgroundTint="@color/light_gray2"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="8dp">
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="6dp">
 
         <ImageView
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
             android:src="@drawable/ic_coin" />
 
         <TextView
             android:id="@+id/itemPriceTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="11dp"
+            android:layout_marginStart="6dp"
             android:text="2500"
             android:textColor="@color/black"
-            android:textSize="20sp" />
+            android:textSize="15sp"
+            android:textStyle="bold" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="54dp"
+        android:layout_marginTop="24dp"
+        android:gravity="end"
         android:orientation="horizontal">
-
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
 
         <TextView
             android:id="@+id/btnCancel"
@@ -60,20 +57,23 @@
             android:layout_height="wrap_content"
             android:clickable="true"
             android:focusable="true"
+            android:padding="8dp"
             android:text="취소"
             android:textColor="#A6A6A6"
-            android:textSize="20sp" />
+            android:textSize="14sp" />
 
         <TextView
             android:id="@+id/btnBuy"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
+            android:layout_marginStart="8dp"
             android:clickable="true"
             android:focusable="true"
+            android:padding="8dp"
             android:text="구매하기"
             android:textColor="@color/blue"
-            android:textSize="20sp" />
+            android:textSize="14sp"
+            android:textStyle="bold" />
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## 📝 Explanation
- 기록탭(날짜/체중) 스크롤이 끝까지 되지 않는 문제 수정
- 아이템 구매 alert창 사이즈 줄임


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout consistency across multiple screens
  * Refined text sizing for enhanced readability
  * Enhanced button and icon appearance
  * Optimized dialog positioning and content alignment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->